### PR TITLE
birdeye button

### DIFF
--- a/content.js
+++ b/content.js
@@ -17,6 +17,7 @@ function addRugcheckLink() {
             const widgetButtonContainer = document.createElement('div');
             const refreshButton = document.createElement('button')
 	      		const closeButton = document.createElement('button');
+            const birdeyeButton = document.createElement('button');
             const collapseButton = document.createElement('button')
             const titleSpan = document.createElement('span')
 
@@ -39,6 +40,14 @@ function addRugcheckLink() {
             collapseButton.style.padding = '.25rem';
             collapseButton.style.transition = 'all 100ms';
             
+            birdeyeButton.textContent = 'Open in birdeye 🦅';
+            birdeyeButton.style.backgroundColor = 'black';
+            birdeyeButton.style.border = 'solid 1px white';
+            birdeyeButton.style.fontWeight = 'bold';
+            birdeyeButton.style.padding = '.25rem';
+            birdeyeButton.style.transition = 'all 100ms';
+            birdeyeButton.style.color = 'white';
+
             closeButton.textContent = 'Close ❌';
             closeButton.style.backgroundColor = 'black';
             closeButton.style.border = 'solid 1px white';
@@ -74,6 +83,7 @@ function addRugcheckLink() {
             widgetButtonContainer.appendChild(titleSpan);
             widgetButtonContainer.appendChild(refreshButton);
             widgetButtonContainer.appendChild(collapseButton);
+            widgetButtonContainer.appendChild(birdeyeButton);
             widgetButtonContainer.appendChild(closeButton);
             widgetContainer.appendChild(widgetButtonContainer)
             widgetContainer.appendChild(rugcheckIframe)
@@ -106,6 +116,11 @@ function addRugcheckLink() {
             closeButton.addEventListener('click', () => {
               widgetContainer.remove(); // This will remove the widgetContainer from the document
             });
+           
+            birdeyeButton.addEventListener('click', () => {
+              window.open(`https://birdeye.so/token/${token}?chain=solana`, 'birdeyeWindow${token}', 'width=1920,height=1080,left=0,top=0');
+            });
+
             collapseButton.addEventListener('click', () => {
               if (showWidget) {
                 collapseButton.textContent = 'Show ⬆️';


### PR DESCRIPTION
cuts the time by 15 seconds from copy paste token address in birdeye site to open with button, in order to view a closer to real-time transaction feed in less hassle and time since dexscreener around 20 behind. this will open in a new window instead of a tab so to drag onto another area on your monitors. it's window size is 1920x1080 so you can fit 4 on a 4k screen. since I'm sure you have at least 3 4k screens for decent screen real estate (but you tried to connect 4 since the 4090 has 5 ports but can only use 3 at a time) I know this is for rugcheck but I find it a useful addition and wanted to share.  I will continue down my fork and add features if the merge doesn't happen, but this seems a good starting point to add some time saving additions for gained efficiency in making money out of nonsense. 